### PR TITLE
moved code of conduct to within the repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+mRelief is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all mRelief spaces, including [give a list of your spaces, eg "our mailing lists and IRC channel"], both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the mRelief Team.
+
+Some mRelief spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+
+Harassment includes:
+
+Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, or religion.
+Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+Deliberate misgendering or use of ‘dead’ or rejected names.
+Gratuitous or off-topic sexual images or behaviour  in spaces where they’re not appropriate.
+Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
+Threats of violence.
+Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm.
+Deliberate intimidation.
+Stalking or following.
+Harassing photography or recording, including logging online activity for harassment purposes.
+Sustained disruption of discussion.
+Unwelcome sexual attention.
+Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+Continued one-on-one communication after requests to cease.
+Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect vulnerable people from intentional abuse.
+Publication of non-harassing private communication.
+mRelief prioritizes marginalized people’s safety over privileged people’s comfort. mRelief Team reserves the right not to act on complaints regarding:
+
+‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
+Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
+Communicating in a ‘tone’ you don’t find congenial
+Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+Reporting
+If you are being harassed by a member of mRelief, notice that someone else is being harassed, or have any other concerns, please contact the mRelief Team at [email address or other contact point]. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+
+This code of conduct applies to mRelief spaces, but if you are being harassed by a member of mRelief outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by mRelief members, especially the mRelief Leadership Team, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from mRelief based on their past behavior, including behavior outside mRelief spaces and behavior towards people who are not in mRelief.
+
+In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of mRelief members or the general public. We will not name harassment victims without their affirmative consent.
+
+Consequences
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behavior, mRelief Team may take any action they deem appropriate, up to and including expulsion from all mRelief spaces and identification of the participant as a harasser to other mRelief members or the general public.

--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ Here is a Ruby style guide [Ruby style guide.](https://github.com/rubocop-hq/rub
 
 ## Code of Conduct
 
-We expect all contributors of this project to the adhere to the Code of Conduct guidlines outlined [here.](http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy)
+We expect all contributors of this project to the adhere to the Code of Conduct guidlines outlined [here.](./CODE_OF_CONDUCT.md)


### PR DESCRIPTION
This commit is intended to move the code of conduct to within the repository and to name the mRelief organization specifically as the arbiter and enforcer of the code of conduct.